### PR TITLE
Somewhat fleshy skeleton for docker build support. Check it out

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# Base on ubuntu 20.04 We could probably run with a simpler one, but for now, this.
+FROM ubuntu:20.04
+
+LABEL maintainer="Jan Pedersen" \
+  TESLA_ACCOUNT_EMAIL="Configure your Tesla account email" \
+  TESLA_SSO_REFRESH_TOKEN="Configure your Tesla SSO refresh token"
+
+# We could fix the timezone here, for now, run with some default. UTC?
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata
+  
+# Install build support stuff  
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install make git
+
+# Install needed python modules
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential libboost-all-dev libcurlpp-dev libcurl4-openssl-dev rapidjson-dev python3-pip librrd-dev
+RUN python3 -m pip install teslapy
+
+# Build the system. This could be in a seperate docker
+RUN git clone https://github.com/jp-embedded/tesla-cron.git && cd tesla-cron && git submodule update --init --recursive
+
+# Now, build
+RUN cd tesla-cron && make
+
+
+# Everything ready, configure for entrypoint.sh
+COPY entrypoint.sh /entrypoint.sh
+CMD ["/entrypoint.sh"]

--- a/README-docker.md
+++ b/README-docker.md
@@ -1,0 +1,9 @@
+# To get a Docker build
+
+* Check out the code
+* Clone the submodules using `git submodule update --init --recursive`
+* Build the docker file, using `docker build . -t tesla-cron`
+* Obtain a Tesla refresh token for your account. This can be generated at eg TeslaFi or the Tesla Access Token Generator chrome extension.
+* Run the docker file, using something similar to `docker run -e TESLA_ACCOUNT_EMAIL=<your account email> -e TESLA_SSO_REFRESH_TOKEN=<your refresh token>`
+
+Thats it, really.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# This scripts updates the auth, then starts the cron job.
+
+# Helper functions.
+function die() {
+    echo "Fatal error: " "$@"
+    exit 1
+}
+
+function log() {
+    DATE=`date +"%Y-%m-%dT%H:%M:%S"`
+    echo $DATE ">> $@"
+}
+
+# TODO: Check the environment variables are actually set
+
+log "Setting up authentification"
+# Run the auth setup 
+# A NEW, NON-INTERACTIVE AUTH SCRIPT IS NEEDED.
+# python3 set-auth.py "${TESLA_ACCOUNT_EMAIL}" "${TESLA_SSO_REFRESH_TOKEN}" || die "Unable to setup refresh token"
+
+log "Running tesla-cron"
+# Auth up, run the cronjob
+exec ./tesla-cron/tesla_cron


### PR DESCRIPTION
Hej Jan

Et lidt fleshet skelet. Der er nogle skønhedsfejl, men hvis du er interesseret, burde det være OK, at tage den herfra:
* Containeren ender med at være UTC. Man skal rode lidt med tzdata for at få den til at være Europe/Copenhagen, og det når jeg ikke i dag.
* Det er nok ikke smart at pulle github repoet fra docker bygge skriptet. Normalt kopierer man de filer man vil bygge med, ind i containeren, men jeg har ikke helt overblik over dine filer, så det var nemmere på det her tidspunkt at pulle dem fra github. 
* Der skal laves et ikke-interaktivt auth script.
* Det er nok ikke smart at tage fra ubuntu:20.04 -- det er et stort layer. Tager også tid at hente pakkerne. Men, det er en slags engangs-omkostning, så ... 

Håber du kan bruge det til noget!

(Det kan jo så udvides med f.eks. en environment variable til en mqtt-broker, som den så kan sende info til. Så ville man ultra nemt kunne hive det derfra over i f.eks. en influxdb + grafana kombi, som virkeligt er "den moderne" måde at lave nice grafer på ;-) ).